### PR TITLE
Modify package `__version__` attribute formatting

### DIFF
--- a/mahautils/__init__.py
+++ b/mahautils/__init__.py
@@ -9,8 +9,4 @@ from . import generic_objects
 
 
 # PROGRAM VERSION ------------------------------------------------------------
-_VERSION_MAJOR = 0
-_VERSION_MINOR = 0
-_VERSION_PATCH = 0
-
-__version__ = f'{_VERSION_MAJOR}.{_VERSION_MINOR}.{_VERSION_PATCH}'
+__version__ = '1.0.0'


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Changed format of package version number in `mahautils/__init__.py` to use string instead of f-string
  - See reference links below.  It appears that `setuptools` requires specific syntax for reading attributes from a file, and the previous f-string did not function as expected.  One possibility (although it would require more debugging to determine) is that `setuptools` was attempting to read the f-string statically and obtaining unexpected results.

## Notes and References
- Reading package version when building package
  - https://stackoverflow.com/questions/58202909/modulenotfounderror-when-using-setup-cfg-and-version-accessed-with-attr
  - https://github.com/pypa/setuptools/pull/1753
  - https://github.com/pypa/setuptools/issues/2530
  - https://github.com/pypa/setuptools/issues/1724