### PR TITLE
Validate order of interpolation axes in `mahautils.multics.VTKFile.interpolate()`

### DIFF
--- a/tests/multics/test_vtk.py
+++ b/tests/multics/test_vtk.py
@@ -691,6 +691,30 @@ class Test_VTKFile(unittest.TestCase):
                     method            = 'linear'
                 )
 
+        with self.subTest(arg='query_points', issue='duplicate_axes'):
+            with self.assertRaises(ValueError):
+                self.vtk_read_unit_convert.interpolate(
+                    identifier        = 'pFilm[bar]',
+                    query_points      = [[-2, 0, 0], [0, 3, 0], [0, -1, 0]],
+                    interpolator_type = 'griddata',
+                    output_units      = 'bar',
+                    query_point_units = 'mm',
+                    interpolate_axes  = 'xyx',
+                    method            = 'linear'
+                )
+
+        with self.subTest(arg='query_points', issue='wrong_axes_order'):
+            with self.assertRaises(ValueError):
+                self.vtk_read_unit_convert.interpolate(
+                    identifier        = 'pFilm[bar]',
+                    query_points      = [[-2, 0, 0], [0, 3, 0], [0, -1, 0]],
+                    interpolator_type = 'griddata',
+                    output_units      = 'bar',
+                    query_point_units = 'mm',
+                    interpolate_axes  = 'yxz',
+                    method            = 'linear'
+                )
+
     def test_is_scalar(self):
         # Verifies that scalar data can be identified correctly
         with self.subTest(unit_conversion_enabled='True'):


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Throw error if user attempts to interpolate VTK data and doesn't provide axes in order: `(x, y, z)`.  This reduces the risk of bugs (i.e., if user thinks that setting `interpolate_axes=('y', 'x')` allows them to provide points as `(y, x)`)
  - Another alternative would have been to allow the user to specify a different order of axes and then use this order when interpolating.  However, this would likely increase the risk of bugs, so enforcing a consistent order `(x, y, z)` is arguably the most robust approach

## Tests and Validation
- Added tests to confirm that errors are thrown if coordinate axes are not provided in the expected order