### PR TITLE
Fixed issue in which simulation results with "nan(ind)" couldn't be parsed

### DIFF
--- a/mahautils/multics/simresults.py
+++ b/mahautils/multics/simresults.py
@@ -609,8 +609,11 @@ class SimResults(MahaMulticsConfigFile):
 
                 # Parse simulation data
                 try:
+                    # Replace "nan(ind)" with "nan" since MSVC compiler outputs
+                    # NaN as "nan(ind)" but this can't be converted by NumPy
                     data_array = np.transpose(np.array(
-                        [x.split() for x in self.contents[i+1:]],
+                        [x.replace('nan(ind)', 'nan').split()
+                         for x in self.contents[i+1:]],
                         dtype=np.float64,
                     ))
 


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Simulations compiled with MSVC output "nan(ind)" to represent NaN but this can't be converted by NumPy, so this change replaces "nan(ind)" with "nan" when reading the file

## Notes and References
- https://stackoverflow.com/questions/15288406/what-is-the-difference-between-ind-and-nan-numbers