### PR TITLE
Add method to delete item from `Dictionary` at a specified index

### DIFF
--- a/mahautils/utils/dictionary.py
+++ b/mahautils/utils/dictionary.py
@@ -189,6 +189,22 @@ class Dictionary(OrderedDict[K, V]):
     def str_pad_right(self, str_pad_right: int):
         self._str_pad_right = int(str_pad_right)
 
+    def delete_index(self, index: int) -> None:
+        """Removes an item from the dictionary based on its index
+
+        Items can easily be removed from the dictionary by key (example: to
+        remove an item with key ``'myKey'`` from a dictionary, simply call
+        ``del dictionary['myKey']``).  This method extends this functionality
+        and allows items to be removed based on their position in the
+        dictionary.
+
+        Parameters
+        ----------
+        index : int
+            The index of the item to remove from the dictionary
+        """
+        del self[list(self.keys())[index]]
+
     def index(self, key: K) -> int:
         """Returns the index of a key in the dictionary
 

--- a/tests/utils/test_dictionary.py
+++ b/tests/utils/test_dictionary.py
@@ -257,6 +257,47 @@ class Test_Dictionary_Index(Test_Dictionary):
             self.dictionary.index('nonexistent_key')
 
 
+class Test_Dictionary_Delete(Test_Dictionary):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dictionary = Dictionary({'a': 0, 'b': 1, 'c': 3, 'd': 4, 'e': 5, 'f': 6})
+
+    def test_delete_key(self):
+        # Verifies that items can be removed from the dictionary by key
+        self.assertDictEqual(
+            self.dictionary,
+            {'a': 0, 'b': 1, 'c': 3, 'd': 4, 'e': 5, 'f': 6})
+
+        del self.dictionary['b']
+        del self.dictionary['f']
+
+        self.assertDictEqual(
+            self.dictionary,
+            {'a': 0, 'c': 3, 'd': 4, 'e': 5})
+
+    def test_delete_index(self):
+        # Verifies that items can be removed from the dictionary by index
+        self.assertDictEqual(
+            self.dictionary,
+            {'a': 0, 'b': 1, 'c': 3, 'd': 4, 'e': 5, 'f': 6})
+
+        self.dictionary.delete_index(3)
+        self.assertDictEqual(
+            self.dictionary,
+            {'a': 0, 'b': 1, 'c': 3, 'e': 5, 'f': 6})
+
+        self.dictionary.delete_index(4)
+        self.assertDictEqual(
+            self.dictionary,
+            {'a': 0, 'b': 1, 'c': 3, 'e': 5})
+
+        self.dictionary.delete_index(-2)
+        self.assertDictEqual(
+            self.dictionary,
+            {'a': 0, 'b': 1, 'e': 5})
+
+
 class Test_Dictionary_Insert(Test_Dictionary):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Major Changes and Improvements
- Added new method `mahautils.utils.Dictionary.delete_index()` that allows items in an ordered dictionary to be deleted based on position