### PR TITLE
Fix bug in which invalid Maha Multics simulation results files did not throw exception when parsed

### DIFF
--- a/mahautils/multics/simresults.py
+++ b/mahautils/multics/simresults.py
@@ -518,13 +518,19 @@ class SimResults(MahaMulticsConfigFile):
         )
 
         # Extract list of variables in "printDict"
-        sim_results_vars, comments, _, _ = self.extract_section_by_keyword(
+        sim_results_vars, comments, _, num_sec = self.extract_section_by_keyword(
             section_label      = 'printDict',
             begin_regex        = r'^\s*printDict\s*{\s*',
             end_regex          = r'^\s*}\s*$',
             section_line_regex = r'^\s*([@?])\s*([\w\d\._]+)\s+\[([^\s]+)\]\s*$',
             max_sections       = 1,
         )
+
+        if num_sec == 0:
+            raise InvalidSimResultsFormatError(
+                'Unable to find "printDict" section in simulation results '
+                f'file "{self.path}"'
+            )
 
         group_name = None
         for i, var in enumerate(sim_results_vars):

--- a/tests/_sample_files/simulation_results_08.txt
+++ b/tests/_sample_files/simulation_results_08.txt
@@ -1,0 +1,37 @@
+# Title: Sample simulation Results 1     
+
+# To adjust what values to print, specify "@" or "?" to indicate whether
+# the variable is required, the variable name, and the output units
+printDictionary{
+    @t          [s]
+
+    # Body Position
+    ?xBody      [m]
+    ?yBody      [mm]
+    ?zBody      [m]
+
+    # Speed
+    ?vxBody     [micron/s]
+
+    # Spring Force
+    ?FxSpring   [N]
+    ?FySpring   [N]
+    ?FzSpring   [N]
+
+    # Torque
+    ?MxBody     [N*m]
+}
+
+$t:s:Sim Time$xBody:m:Body casing frame position in x$yBody:mm:Body casing frame position in y$zBody:m:$FxSpring:N:$FySpring:N:Spring Force y$FzSpring:N:Spring Force z
+#_OPTIONs: THERMAL = 0, CAV = 0, FFI = 1, MASS_CON = 0, INTERP = 1
+0       3.4     4.2   2.1    -1000    933   0
+1	0  0  -4		9	3   933
+2   9   3.32   3    	99.3 3 0.0021
+3    434  23.323   93.24323      3    0 -220.32332
+4.00   323 	43.323			399	-0.3   32    959
+5   4.32   23.5    69   32	-0.32    3.54993
+6  34       0.42343			0.0000000234   3.21   5 1
+7   4.3   34    990     3   1 2
+8  3000     -232        43      3.32    0.543   114
+9  0    0.001   3693.3	9.4     0.1			3332.4
+10   10 10  10  10  10.000 10.00

--- a/tests/multics/test_simresults.py
+++ b/tests/multics/test_simresults.py
@@ -267,6 +267,12 @@ class Test_SimResults_Parse(Test_SimResults):
             TEST_FLOAT_TOLERANCE
         )
 
+    def test_missing_printdict(self):
+        # Verifies that an error is thrown if attempting to read a simulation
+        # results file without a "printDict" section
+        with self.assertRaises(InvalidSimResultsFormatError):
+            SimResults(SAMPLE_FILES_DIR / 'simulation_results_08.txt')
+
 
 class Test_SimResults_ReadProperties(Test_SimResults):
     def setUp(self) -> None:


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Previously, the `mahautils.multics.SimResults` class didn't throw an exception if parsing a file with invalid format (such as a blank text file).  This change adds an exception if the file being parsed doesn't have "printDict" section to address this issue