### PR TITLE
Update SimViewer shape annotation and image export options

### DIFF
--- a/mahautils/multics/sim_results_viewer/panel/settings_general.py
+++ b/mahautils/multics/sim_results_viewer/panel/settings_general.py
@@ -149,4 +149,56 @@ def render_general_settings(config_general: dict):
                     'field': 'freeze-uirevision'},
             trigger='hover',
         ),
+        dash.html.Br(),
+        dash.html.Br(),
+        dash.html.H4('Image Export Options'),
+        dash.html.Hr(),
+        dash.html.H5('Export Type'),
+        dash.dcc.Dropdown(
+            options=['png', 'jpeg', 'webp', 'svg'],
+            value=config_general['image_export_type'],
+            id={'component': 'plot-config', 'tab': 'general',
+                'field': 'image_export_type'},
+            clearable=False,
+            multi=False,
+        ),
+        dash.html.Br(),
+        dash.html.H5('Aspect Ratio'),
+        dash.html.P(
+            ('Output aspect ratio for exported images (width x height). '
+             'Leave blank to use window size'),
+            style={'marginBottom': UI_DESCRIPTION_MARGIN_BELOW},
+        ),
+        dash.html.Div([
+            dbc.Input(
+                debounce=True,
+                id={'component': 'plot-config', 'tab': 'general',
+                    'field': 'image_export_width'},
+                value=config_general['image_export_width'],
+                style={'display': 'inline-block', 'width': '100px'},
+            ),
+            dash.html.P('  x  ', style={'display': 'inline-block',
+                                        'whiteSpace': 'pre'}),
+            dbc.Input(
+                debounce=True,
+                id={'component': 'plot-config', 'tab': 'general',
+                    'field': 'image_export_height'},
+                value=config_general['image_export_height'],
+                style={'display': 'inline-block', 'width': '100px'},
+            ),
+        ]),
+        dash.html.Br(),
+        dash.html.H5('Resolution'),
+        dash.html.P(
+            ('Setting this to n will increase the exported image '
+             'resolution by a factor of n'),
+            style={'marginBottom': UI_DESCRIPTION_MARGIN_BELOW},
+        ),
+        dbc.Input(
+            debounce=True,
+            id={'component': 'plot-config', 'tab': 'general',
+                'field': 'image_export_scale'},
+            value=config_general['image_export_scale'],
+            style={'width': '100px'},
+        ),
     ]

--- a/mahautils/multics/sim_results_viewer/plotting.py
+++ b/mahautils/multics/sim_results_viewer/plotting.py
@@ -47,9 +47,10 @@ def graph():
                     'eraseshape',
                 ],
                 'toImageButtonOptions': {
-                    'format': 'png',
+                    'format': 'svg',
                     'width': None,
                     'height': None,
+                    'scale': 1,
                 },
                 'scrollZoom': True,
                 'showAxisDragHandles': True,

--- a/mahautils/multics/sim_results_viewer/store.py
+++ b/mahautils/multics/sim_results_viewer/store.py
@@ -39,6 +39,10 @@ default_plot_config_general: Dict[str, Any] = {
     'width_per_y_axis': 0.1,
     'hovermode': 'closest',
     'freeze_uirevision': False,
+    'image_export_type': 'png',
+    'image_export_width': None,
+    'image_export_height': None,
+    'image_export_scale': 1,
 }
 
 default_plot_config_x: Dict[str, Any] = {


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Major Changes and Improvements
- Added options to create shape annotations on SimViewer plots
- Improved SimViewer zoom interactivity (allow zoom by scrolling, show controls to drag plot window to zoom)
- Added options for user to control image export format, size, and resolution

## Notes and References
- https://plotly.com/python/configuration-options/
- https://dash.plotly.com/dash-core-components/graph