### PR TITLE
Fix bug in `Point` iterable behavior

### DIFF
--- a/mahautils/shapes/geometry/point.py
+++ b/mahautils/shapes/geometry/point.py
@@ -9,7 +9,7 @@ floating-point numbers.
 """
 
 import math
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, overload, Tuple, Union
 
 import numpy as np
 
@@ -73,6 +73,17 @@ class Point(Geometry):
                 return False
 
         return True
+
+    @overload
+    def __getitem__(self, index: int) -> float:
+        ...  # pragma: no cover
+
+    @overload
+    def __getitem__(self, index: slice) -> Tuple[float, ...]:
+        ...  # pragma: no cover
+
+    def __getitem__(self, idx):
+        return self._coordinates[idx]
 
     def __iter__(self):
         self.__iter_index = 0

--- a/tests/shapes/geometry/test_point.py
+++ b/tests/shapes/geometry/test_point.py
@@ -84,6 +84,25 @@ class Test_Point(unittest.TestCase):
         with self.subTest(dim=3):
             self.assertEqual(str(self.point3D), '(3, 4, 5)')
 
+    def test_getitem(self):
+        # Verifies that point coordinates can be retrieved by index
+        with self.subTest(dimensions=2):
+            with self.subTest(access='int'):
+                self.assertEqual(self.point2D[0], 1.5)
+                self.assertEqual(self.point2D[1], 2.5)
+
+            with self.subTest(access='slice'):
+                self.assertTupleEqual(self.point2D[0:], (1.5, 2.5))
+
+        with self.subTest(dimensions=3):
+            with self.subTest(access='int'):
+                self.assertEqual(self.point3D[0], 3)
+                self.assertEqual(self.point3D[1], 4)
+                self.assertEqual(self.point3D[2], 5)
+
+            with self.subTest(access='slice'):
+                self.assertTupleEqual(self.point3D[1:], (4, 5))
+
     def test_iterable(self):
         # Verifies that it is possible to iterate over the coordinates of the
         # point. Each is tested twice to ensure iterables "reset" correctly


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Fixed a bug in which the iterator for `mahautils.shapes.Point` objects was not reset correctly.  This previously resulted in the point coordinates being set to an empty list after the first iteration through the list

**Example**
_Previous Behavior_

```python
>>> from mahautils.shapes import Point
>>> point._coordinates = (1, 2, 3, 4)
>>> list(point)
[1, 2, 3, 4]
>>> list(point)
[]
```

_Updated Behavior_

```python
>>> from mahautils.shapes import Point
>>> point._coordinates = (1, 2, 3, 4)
>>> list(point)
[1, 2, 3, 4]
>>> list(point)
[1, 2, 3, 4]
```

## Minor Updates
- Added `mahautils.shapes.Point.__getitem__()` definition so that point coordinates can be accessed by index and so that `Point` objects can be used similar to Python lists
  - This can be useful, for instance, so that `Point` objects can be used as inputs for functions in other packages that expect lists of `float`, such as [scipy.spatial.Voronoi](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Voronoi.html)

## Tests and Validation
- Added new tests that check that iterable conversion of `Point` instances functions as expected

## Notes and References
- https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes