### PR TITLE
Change README image to use external URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Once you've installed the MahaUtils package, simply open a terminal and launch S
 $ SimViewer
 ```
 
+> :test_tube: **Try It Out!**
+>
+> Want to give the GUI a try?  The quickest way is to launch a GitHub Codespaces instance:
+>
+> [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nathan-hess/maha-research-utils)
+>
+> If you need some files to experiment with, give these a try: [`sim_results_underdamped.txt`](https://github.com/nathan-hess/maha-research-utils/blob/main/demo_files/sim_results_underdamped.txt) and [`sim_results_overdamped.txt`](https://github.com/nathan-hess/maha-research-utils/blob/main/demo_files/sim_results_overdamped.txt)
+
 Here's a demonstration of what it looks like in action:
 
 ![](https://raw.githubusercontent.com/nathan-hess/maha-research-utils/main/docs/source/usage/simviewer/images/simviewer_demo.gif)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ SimViewer
 
 Here's a demonstration of what it looks like in action:
 
-![Demonstration of plotting Maha Multics simulation results with MahaUtils SimViewer GUI](docs/source/usage/simviewer/images/simviewer_demo.gif)
+![](https://raw.githubusercontent.com/nathan-hess/maha-research-utils/main/docs/source/usage/simviewer/images/simviewer_demo.gif)
 
 
 ### Reading and Editing Maha Multics Files

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ SimViewer
 >
 > If you need some files to experiment with, give these a try: [`sim_results_underdamped.txt`](https://github.com/nathan-hess/maha-research-utils/blob/main/demo_files/sim_results_underdamped.txt) and [`sim_results_overdamped.txt`](https://github.com/nathan-hess/maha-research-utils/blob/main/demo_files/sim_results_overdamped.txt)
 
-Here's a demonstration of what it looks like in action:
+The primary aim of the SimViewer GUI is to provide a visually-appealing, configurable interface for quickly reviewing and comparing simulation results, with sufficient control over plot styling to generate and export presentation-quality plots.  Here's a demonstration of what it looks like in action:
 
 ![](https://raw.githubusercontent.com/nathan-hess/maha-research-utils/main/docs/source/usage/simviewer/images/simviewer_demo.gif)
 


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Changed README image path so that it uses an external URL so that the image will be correctly displayed in the PyPI description
- Added link to open repository in GitHub Codespaces

## Notes and References
- https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github