### PR TITLE
Parse additional metadata from simulation results files and display in SimViewer

### DIFF
--- a/mahautils/multics/sim_results_viewer/panel/utils_generate_table.py
+++ b/mahautils/multics/sim_results_viewer/panel/utils_generate_table.py
@@ -25,14 +25,39 @@ def generate_file_table_body(sim_results_files: SIM_RESULTS_DICT_T,
                              metadata: Dict[str, Dict[str, Any]]):
     """Populates the simulation results file table with all currently uploaded
     simulation results files"""
+    description_style = {
+        'fontSize': 12,
+        'marginTop': 0,
+        'marginBottom': 0,
+        'paddingTop': 0,
+        'paddingBottom': 0,
+    }
+
     contents = []
     for _, key in enumerate(sim_results_files.keys()):
+        display_metadata = []
+        if (title := sim_results_files[key].title) is not None:
+            display_metadata.append(
+                dash.html.P(
+                    dash.html.I(f'Title: {title}'),
+                    style=description_style,
+                )
+            )
+
+        if len(display_metadata) == 0:
+            file_id_description = dash.html.H6(key)
+        else:
+            file_id_description = dash.html.Details(
+                [dash.html.Summary(key, style={'marginBottom': 5})]
+                + display_metadata
+            )
+
         contents.append(dash.html.Tr([
             dash.html.Td(dbc.Switch(
                 value=metadata[key]['enabled'],
                 id={'component': 'file-table-switch', 'key': key},
             )),
-            dash.html.Td(dash.html.H6(key)),
+            dash.html.Td(file_id_description),
             dash.html.Td(dbc.Button(
                 dash.html.I(className='bi bi-trash'),
                 color='danger',

--- a/mahautils/multics/sim_results_viewer/panel/utils_generate_table.py
+++ b/mahautils/multics/sim_results_viewer/panel/utils_generate_table.py
@@ -26,23 +26,70 @@ def generate_file_table_body(sim_results_files: SIM_RESULTS_DICT_T,
     """Populates the simulation results file table with all currently uploaded
     simulation results files"""
     description_style = {
-        'fontSize': 12,
+        'fontSize': 12.5,
         'marginTop': 0,
         'marginBottom': 0,
         'paddingTop': 0,
         'paddingBottom': 0,
     }
 
+    description_header_style = description_style.copy()
+    description_header_style['fontSize'] += 1.5
+
     contents = []
     for _, key in enumerate(sim_results_files.keys()):
         display_metadata = []
-        if (title := sim_results_files[key].title) is not None:
+
+        title = sim_results_files[key].title
+        sim_version = sim_results_files[key].sim_version
+        if (title is not None) or (sim_version is not None):
             display_metadata.append(
-                dash.html.P(
-                    dash.html.I(f'Title: {title}'),
-                    style=description_style,
-                )
+                dash.html.B('Simulation Metadata',
+                            style=description_header_style)
             )
+
+            if title is not None:
+                display_metadata.append(
+                    dash.html.P(
+                        [dash.html.B('Title: '), title],
+                        style=description_style,
+                    )
+                )
+
+            if sim_version is not None:
+                display_metadata.append(
+                    dash.html.P(
+                        [dash.html.B('Version: '), sim_version],
+                        style=description_style,
+                    )
+                )
+
+        maha_multics_version = sim_results_files[key].maha_multics_version
+        maha_multics_commit = sim_results_files[key].maha_multics_commit
+        if (maha_multics_version is not None) or (maha_multics_commit is not None):
+            display_metadata.append(dash.html.P())
+            display_metadata.append(
+                dash.html.B('Maha Multics Metadata',
+                            style=description_header_style)
+            )
+
+            if maha_multics_version is not None:
+                display_metadata.append(
+                    dash.html.P(
+                        [dash.html.B('Version: '),
+                         maha_multics_version],
+                        style=description_style,
+                    )
+                )
+
+            if maha_multics_commit is not None:
+                display_metadata.append(
+                    dash.html.P(
+                        [dash.html.B('Commit: '),
+                         maha_multics_commit],
+                        style=description_style,
+                    )
+                )
 
         if len(display_metadata) == 0:
             file_id_description = dash.html.H6(key)

--- a/mahautils/multics/sim_results_viewer/panel/utils_generate_table.py
+++ b/mahautils/multics/sim_results_viewer/panel/utils_generate_table.py
@@ -67,7 +67,9 @@ def generate_file_table_body(sim_results_files: SIM_RESULTS_DICT_T,
         maha_multics_version = sim_results_files[key].maha_multics_version
         maha_multics_commit = sim_results_files[key].maha_multics_commit
         if (maha_multics_version is not None) or (maha_multics_commit is not None):
-            display_metadata.append(dash.html.P())
+            if (title is not None) or (sim_version is not None):
+                display_metadata.append(dash.html.P())
+
             display_metadata.append(
                 dash.html.B('Maha Multics Metadata',
                             style=description_header_style)

--- a/tests/_sample_files/simulation_results_01.txt
+++ b/tests/_sample_files/simulation_results_01.txt
@@ -21,7 +21,9 @@ printDict{
     # Torque
     ?MxBody     [N*m]
 }
-
+# Multics Version: v4116.7.30
+# Multics Git Commit Hash: fb8aa721e23fb7b0c751ec31c258cdc3f85a4c31
+# Main Sketch Version: v8.2.8
 $t:s:Sim Time$xBody:m:Body casing frame position in x$yBody:mm:Body casing frame position in y$zBody:m:$FxSpring:N:$FySpring:N:Spring Force y$FzSpring:N:Spring Force z
 #_OPTIONs: THERMAL = 0, CAV = 0, FFI = 1, MASS_CON = 0, INTERP = 1
 0       3.4     4.2   2.1    -1000    933   0

--- a/tests/multics/test_simresults.py
+++ b/tests/multics/test_simresults.py
@@ -388,23 +388,30 @@ class Test_SimResults_ReadProperties(Test_SimResults):
         with self.subTest(file_read=False):
             self.assertEqual(SimResults().num_time_steps, 0)
 
-    def test_title(self):
-        # Verifies that title is read correctly from simulation results file
-        with self.subTest(title_present=True):
-            self.assertEqual(self.sim_results_01.title, 'Sample simulation Results 1')
+    def test_metadata(self):
+        # Verifies that metadata fields are read correctly from simulation results file
+        attributes = ['title', 'maha_multics_version', 'maha_multics_commit', 'sim_version']
+        values = ['Sample simulation Results 1', 'v4116.7.30', 'fb8aa721e23fb7b0c751ec31c258cdc3f85a4c31', 'v8.2.8']
 
-        with self.subTest(title_present=False):
-            self.assertIsNone(self.sim_results_02.title)
+        for attr, value in zip(attributes, values):
+            with self.subTest(field=attr):
+                with self.subTest(attr_present=True):
+                    self.assertEqual(getattr(self.sim_results_01, attr), value)
 
-    def test_set_title(self):
-        # Verifies that the title can be changed
-        with self.subTest(valid=True):
-            self.sim_results_01.title = 'my New Title'
-            self.assertEqual(self.sim_results_01.title, 'my New Title')
+                with self.subTest(attr_present=False):
+                    self.assertIsNone(getattr(self.sim_results_02, attr))
 
-        with self.subTest(valid=False):
-            with self.assertRaises(TypeError):
-                self.sim_results_01.title = 75992
+    def test_set_metadata(self):
+        # Verifies that metadata fields can be changed
+        for attr in ['title', 'maha_multics_version', 'maha_multics_commit', 'sim_version']:
+            with self.subTest(field=attr):
+                with self.subTest(valid=True):
+                    setattr(self.sim_results_01, attr, 'my New Title')
+                    self.assertEqual(getattr(self.sim_results_01, attr), 'my New Title')
+
+                with self.subTest(valid=False):
+                    with self.assertRaises(TypeError):
+                        setattr(self.sim_results_01, attr, 75992)
 
     def test_variables(self):
         # Verifies that "variables" attribute functions correctly
@@ -876,6 +883,9 @@ class Test_SimResults_UpdateContents(Test_SimResults):
                 '    # Torque',
                 '    ?MxBody      [N*m]',
                 '}',
+                '# Multics Version: v4116.7.30',
+                '# Multics Git Commit Hash: fb8aa721e23fb7b0c751ec31c258cdc3f85a4c31',
+                '# Main Sketch Version: v8.2.8',
                 ('$t:s:Sim Time$xBody:m:Body casing frame position in x'
                  '$yBody:mm:Body casing frame position in y$zBody:m:$FxSpring:N:'
                  '$FySpring:N:Spring Force y$FzSpring:N:Spring Force z'),
@@ -923,6 +933,9 @@ class Test_SimResults_UpdateContents(Test_SimResults):
                 '    # Torque',
                 '    ?MxBody      [N*m]',
                 '}',
+                '# Multics Version: v4116.7.30',
+                '# Multics Git Commit Hash: fb8aa721e23fb7b0c751ec31c258cdc3f85a4c31',
+                '# Main Sketch Version: v8.2.8',
             ]
         )
 
@@ -956,6 +969,9 @@ class Test_SimResults_UpdateContents(Test_SimResults):
                 '    # Torque',
                 '    ?MxBody      [N*m]',
                 '}',
+                '# Multics Version: v4116.7.30',
+                '# Multics Git Commit Hash: fb8aa721e23fb7b0c751ec31c258cdc3f85a4c31',
+                '# Main Sketch Version: v8.2.8',
                 ('$t:s:Sim Time$xBody:m:Body casing frame position in x'
                  '$yBody:mm:Body casing frame position in y$zBody:m:$FxSpring:N:'
                  '$FySpring:N:Spring Force y$FzSpring:N:Spring Force z'),


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Major Changes and Improvements
- Added feature to `mahautils.multics.SimResults` class: additional metadata (Maha Multics version, Maha Multics Git commit hash, and `main.cpp` version) are now parsed from simulation results files, if provided
- Added a dropdown for each file displayed in the SimViewer GUI showing file metadata, if available