### PR TITLE
Add new methods to perform geometry calculations in `mahautils.shapes` module

### DIFF
--- a/docs/source/_templates/api_reference_class_template.rst
+++ b/docs/source/_templates/api_reference_class_template.rst
@@ -17,6 +17,8 @@
    np
    num
    OpenShape
+   pntA
+   pntB
    PolygonFile
    printDict
    SimResults

--- a/mahautils/__init__.py
+++ b/mahautils/__init__.py
@@ -6,7 +6,7 @@ research work and interacting with the Maha Multics software.
 
 
 # PROGRAM VERSION ------------------------------------------------------------
-__version__ = '0.2.0'
+__version__ = '0.3.0.dev'
 
 
 # PACKAGE MODULES ------------------------------------------------------------

--- a/mahautils/shapes/geometry/circle.py
+++ b/mahautils/shapes/geometry/circle.py
@@ -185,7 +185,7 @@ class Circle(ClosedShape2D):
         Returns
         -------
         float
-            The area of interection between this circle and ``circle``
+            The area of intersection between this circle and ``circle``
         """
         if not isinstance(circle, Circle):
             raise TypeError(

--- a/mahautils/shapes/geometry/circle.py
+++ b/mahautils/shapes/geometry/circle.py
@@ -262,6 +262,10 @@ class Circle(ClosedShape2D):
             repeat_end=repeat_end,
         )
 
+    def reflect(self, pntA: Union[Array_Float2, 'CartesianPoint2D'],
+                pntB: Union[Array_Float2, 'CartesianPoint2D']) -> None:
+        self.center.reflect(pntA=pntA, pntB=pntB)
+
     def rotate(self, center: Union[Array_Float2, CartesianPoint2D],
                angle: float, angle_units: str = 'rad') -> None:
         self.center.rotate(center=center, angle=angle, angle_units=angle_units)

--- a/mahautils/shapes/geometry/circle.py
+++ b/mahautils/shapes/geometry/circle.py
@@ -170,6 +170,53 @@ class Circle(ClosedShape2D):
 
         self._radius = float(radius)
 
+    def intersection_area(self, circle: 'Circle'):
+        """Calculates the area of intersection with another circle
+
+        Calculates the overlapping area of intersection between this circle and
+        another :py:class:`Circle` instance.  Mathematical formulas based on
+        https://mathworld.wolfram.com/Circle-CircleIntersection.html.
+
+        Parameters
+        ----------
+        circle : Circle
+            The circle with which area of intersection is to be calculated
+
+        Returns
+        -------
+        float
+            The area of interection between this circle and ``circle``
+        """
+        if not isinstance(circle, Circle):
+            raise TypeError(
+                'Intersection area can only be calculated with another circle')
+
+        if not self._has_identical_units(circle):
+            raise ValueError(
+                'Circles have different units. Cannot compute intersection area')
+
+        # Distance between circle centers
+        d = self.center.distance_to(circle.center)
+
+        # Maximum and minimum circle radius
+        R = max(self.radius, circle.radius)
+        r = min(self.radius, circle.radius)
+
+        if d >= R + r:
+            # Circles don't overlap
+            return 0.0
+
+        if d <= R - r:
+            # The smaller circle is completely enclosed by the larger circle
+            return math.pi*(r**2)
+
+        return (
+            r**2 * math.acos((d**2 + r**2 - R**2) / (2*d*r))
+            + R**2 * math.acos((d**2 + R**2 - r**2) / (2*d*R))
+            - 0.5 * math.sqrt((-d + r + R) * (d + r - R)
+                              * (d - r + R) * (d + r + R))
+        )
+
     def is_inside(self, point: Union[Array_Float2, CartesianPoint2D],
                   perimeter_is_inside: bool = True) -> bool:
         distance = self.center.distance_to(point)

--- a/mahautils/shapes/geometry/circle.py
+++ b/mahautils/shapes/geometry/circle.py
@@ -136,6 +136,11 @@ class Circle(ClosedShape2D):
         return self.__repr__()
 
     @property
+    def area(self) -> float:
+        """The area of the circle"""
+        return math.pi * (self.radius**2)
+
+    @property
     def center(self) -> CartesianPoint2D:
         """The center of the circle"""
         return self._center

--- a/mahautils/shapes/geometry/point2D.py
+++ b/mahautils/shapes/geometry/point2D.py
@@ -214,35 +214,19 @@ class CartesianPoint2D(Shape2D, Point):
         pntA = CartesianPoint2D(pntA)
         pntB = CartesianPoint2D(pntB)
 
-        # Algorithm based on https://math.stackexchange.com/a/1367732
-        R = pntA.distance_to(pntB)
-        if R == 0:
+        if pntA.distance_to(pntB) == 0:
             raise ValueError('Points on the line must be at a nonzero '
                              'distance from each other')
 
         # Find two possible intersection points
-        ax = 0.5 * (pntA.x + pntB.x)
-        ay = 0.5 * (pntA.y + pntB.y)
+        numerator = (((self.x - pntA.x) / (pntB.x - pntA.x))
+                     - ((self.y - pntA.y) / (pntB.y - pntA.y)))
+        denominator = (((pntB.x - pntA.x) / (pntB.y - pntA.y))
+                       + ((pntB.y - pntA.y) / (pntB.x - pntA.x)))
+        t = 2.0 * numerator / denominator
 
-        rA = self.distance_to(pntA)
-        rB = self.distance_to(pntB)
-        b = 0.5 * (rA**2 - rB**2) / R**2
-        bx = b * (pntB.x - pntA.x)
-        by = b * (pntB.y - pntA.y)
-
-        c = (0.5*(rA**2 + rB**2)/R**2 - b**2 - 0.25)**0.5
-        cx = c * (pntB.y - pntA.y)
-        cy = c * (pntA.x - pntB.x)
-
-        p1 = CartesianPoint2D(ax + bx + cx, ay + by + cy)
-        p2 = CartesianPoint2D(ax + bx - cx, ay + by - cy)
-
-        if self.distance_to(p1) > self.distance_to(p2):
-            self.x = p2.x
-            self.y = p2.y
-        else:
-            self.x = p1.x
-            self.y = p1.y
+        self.x += (pntA.y - pntB.y) * t
+        self.y += (pntB.x - pntA.x) * t
 
     def rotate(self, center: Union[Array_Float2, 'CartesianPoint2D'],
                angle: float, angle_units: str = 'rad') -> None:

--- a/mahautils/shapes/geometry/point2D.py
+++ b/mahautils/shapes/geometry/point2D.py
@@ -218,12 +218,13 @@ class CartesianPoint2D(Shape2D, Point):
             raise ValueError('Points on the line must be at a nonzero '
                              'distance from each other')
 
-        # Find two possible intersection points
-        numerator = (((self.x - pntA.x) / (pntB.x - pntA.x))
-                     - ((self.y - pntA.y) / (pntB.y - pntA.y)))
-        denominator = (((pntB.x - pntA.x) / (pntB.y - pntA.y))
-                       + ((pntB.y - pntA.y) / (pntB.x - pntA.x)))
-        t = 2.0 * numerator / denominator
+        A = np.array([[pntB.x - pntA.x, pntB.y - pntA.y],
+                      [pntB.y - pntA.y, pntA.x - pntB.x]])
+        b = np.array([[self.x - pntA.x],
+                      [self.y - pntA.y]])
+        x = np.linalg.solve(A, b)
+
+        t = 2.0 * x[1]
 
         self.x += (pntA.y - pntB.y) * t
         self.y += (pntB.x - pntA.x) * t

--- a/mahautils/shapes/geometry/point2D.py
+++ b/mahautils/shapes/geometry/point2D.py
@@ -209,6 +209,32 @@ class CartesianPoint2D(Shape2D, Point):
     def points(self) -> Tuple[np.ndarray, ...]:
         return (np.array([self.x, self.y]),)
 
+    def reflect(self, pntA: Union[Array_Float2, 'CartesianPoint2D'],
+                pntB: Union[Array_Float2, 'CartesianPoint2D']) -> None:
+        pntA = CartesianPoint2D(pntA)
+        pntB = CartesianPoint2D(pntB)
+
+        if pntA.distance_to(pntB) == 0:
+            raise ValueError('Points on the line must be at a nonzero '
+                             'distance from each other')
+
+        # Slope of line across which point is to be reflected
+        mL = (pntB.y - pntA.y) / (pntB.x - pntA.x)
+
+        # Slope of line between original point and reflected point
+        mR = -(pntB.x - pntA.x) / (pntB.y - pntA.y)
+
+        # x-coordinate of intersection point of two lines whose slopes
+        # were calculated above
+        xi = (mL*pntA.x - mR*self.x + self.y - pntA.y) / (mL - mR)
+
+        # Reflected point coordinates
+        xR = 2*(xi - self.x)
+        yR = mR*(xR - self.x) + self.y
+
+        self.x = xR
+        self.y = yR
+
     def rotate(self, center: Union[Array_Float2, 'CartesianPoint2D'],
                angle: float, angle_units: str = 'rad') -> None:
         # Convert angle to radians

--- a/mahautils/shapes/geometry/point2D.py
+++ b/mahautils/shapes/geometry/point2D.py
@@ -214,26 +214,35 @@ class CartesianPoint2D(Shape2D, Point):
         pntA = CartesianPoint2D(pntA)
         pntB = CartesianPoint2D(pntB)
 
-        if pntA.distance_to(pntB) == 0:
+        # Algorithm based on https://math.stackexchange.com/a/1367732
+        R = pntA.distance_to(pntB)
+        if R == 0:
             raise ValueError('Points on the line must be at a nonzero '
                              'distance from each other')
 
-        # Slope of line across which point is to be reflected
-        mL = (pntB.y - pntA.y) / (pntB.x - pntA.x)
+        # Find two possible intersection points
+        ax = 0.5 * (pntA.x + pntB.x)
+        ay = 0.5 * (pntA.y + pntB.y)
 
-        # Slope of line between original point and reflected point
-        mR = -(pntB.x - pntA.x) / (pntB.y - pntA.y)
+        rA = self.distance_to(pntA)
+        rB = self.distance_to(pntB)
+        b = 0.5 * (rA**2 - rB**2) / R**2
+        bx = b * (pntB.x - pntA.x)
+        by = b * (pntB.y - pntA.y)
 
-        # x-coordinate of intersection point of two lines whose slopes
-        # were calculated above
-        xi = (mL*pntA.x - mR*self.x + self.y - pntA.y) / (mL - mR)
+        c = (0.5*(rA**2 + rB**2)/R**2 - b**2 - 0.25)**0.5
+        cx = c * (pntB.y - pntA.y)
+        cy = c * (pntA.x - pntB.x)
 
-        # Reflected point coordinates
-        xR = 2*(xi - self.x)
-        yR = mR*(xR - self.x) + self.y
+        p1 = CartesianPoint2D(ax + bx + cx, ay + by + cy)
+        p2 = CartesianPoint2D(ax + bx - cx, ay + by - cy)
 
-        self.x = xR
-        self.y = yR
+        if self.distance_to(p1) > self.distance_to(p2):
+            self.x = p2.x
+            self.y = p2.y
+        else:
+            self.x = p1.x
+            self.y = p1.y
 
     def rotate(self, center: Union[Array_Float2, 'CartesianPoint2D'],
                angle: float, angle_units: str = 'rad') -> None:

--- a/mahautils/shapes/geometry/polygon.py
+++ b/mahautils/shapes/geometry/polygon.py
@@ -149,6 +149,16 @@ class Polygon(ClosedShape2D):
     def points(self, repeat_end: bool = False) -> Tuple[np.ndarray, ...]:
         return self._convert_xy_coordinates_to_points(repeat_end=repeat_end)
 
+    def reflect(self, pntA: Union[Array_Float2, 'CartesianPoint2D'],
+                pntB: Union[Array_Float2, 'CartesianPoint2D']) -> None:
+        reflected_vertices = []
+        for vertex in self._vertices:
+            point = CartesianPoint2D(vertex)
+            point.reflect(pntA=pntA, pntB=pntB)
+            reflected_vertices.append(list(point))
+
+        self._vertices = np.array(reflected_vertices)
+
     def rotate(self, center: Union[Array_Float2, CartesianPoint2D],
                angle: float, angle_units: str = 'rad') -> None:
         # Convert angle to radians

--- a/mahautils/shapes/geometry/polygon.py
+++ b/mahautils/shapes/geometry/polygon.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple, Union
 # Mypy type checking disabled for packages that are not PEP 561-compliant
 import matplotlib.path  # type: ignore
 import numpy as np
+import shapely
 
 from .point import Array_Float2, Point
 from .point2D import CartesianPoint2D
@@ -84,6 +85,11 @@ class Polygon(ClosedShape2D):
             polygon_file_enclosed_conv=polygon_file_enclosed_conv,
             units=units,
         )
+
+    @property
+    def area(self) -> float:
+        """Returns the area of the polygon"""
+        return shapely.Polygon(self.vertices).area
 
     @property
     def vertices(self) -> np.ndarray:

--- a/mahautils/shapes/geometry/polygon.py
+++ b/mahautils/shapes/geometry/polygon.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Tuple, Union
 # Mypy type checking disabled for packages that are not PEP 561-compliant
 import matplotlib.path  # type: ignore
 import numpy as np
-import shapely
+import shapely          # type: ignore
 
 from .point import Array_Float2, Point
 from .point2D import CartesianPoint2D

--- a/mahautils/shapes/geometry/shape.py
+++ b/mahautils/shapes/geometry/shape.py
@@ -143,6 +143,27 @@ class Shape2D(Geometry):
         """
         raise NotImplementedError  # pragma: no cover
 
+    def reflect(self, pntA: Union[Array_Float2, 'CartesianPoint2D'],
+                pntB: Union[Array_Float2, 'CartesianPoint2D']) -> None:
+        """Reflects the shape across a line defined by two points
+
+        Parameters
+        ----------
+        pntA : list or tuple or CartesianPoint2D
+            One point on the line across which the shape is to be reflected
+        pntB : list or tuple or CartesianPoint2D
+            Another point on the line across which the shape is to be reflected
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    def reflect_x(self):
+        """Reflects the shape over the :math:`x`-axis"""
+        self.reflect((0.0, 0.0), (1.0, 0.0))
+
+    def reflect_y(self):
+        """Reflects the shape over the :math:`y`-axis"""
+        self.reflect((0.0, 0.0), (0.0, 1.0))
+
     def rotate(self, center: Union[Array_Float2, 'CartesianPoint2D'],
                angle: float, angle_units: str = 'rad') -> None:
         """Rotates the shape in the :math:`xy`-plane

--- a/mahautils/shapes/geometry/shape_open_closed.py
+++ b/mahautils/shapes/geometry/shape_open_closed.py
@@ -57,6 +57,11 @@ class ClosedShape2D(Shape2D):
         self.polygon_file_enclosed_conv = polygon_file_enclosed_conv
 
     @property
+    def area(self) -> float:
+        """Returns the area enclosed by the shape"""
+        raise NotImplementedError  # pragma: no cover
+
+    @property
     def polygon_file_enclosed_conv(self) -> int:
         """Convention for considering enclosed area when generating a polygon
         file from :py:class:`ClosedShape2D` objects

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ pandas
 plotly
 pyxx
 scipy
+shapely
 vtk

--- a/tests/shapes/geometry/test_circle.py
+++ b/tests/shapes/geometry/test_circle.py
@@ -1,4 +1,5 @@
 import copy
+import math
 import unittest
 
 import numpy as np
@@ -123,6 +124,56 @@ class Test_Circle(unittest.TestCase):
 
         with self.subTest(metric='diameter'):
             self.assertEqual(self.circle.diameter, 2*self.circle_radius)
+
+    def test_intersection_area(self):
+        # Verifies that the intersection area of two circles is calculated correctly
+        r = 68.25331284
+        dx = 673
+        dy = 3.2
+        circle1 = Circle(center=(dx, r + dy), radius=r)
+        circle2 = Circle(center=(r + dx, dy), radius=r)
+
+        analytical_area = r**2 * 0.25 * (2*math.pi - 4)
+        self.assertAlmostEqual(circle1.intersection_area(circle2), analytical_area)
+        self.assertAlmostEqual(circle2.intersection_area(circle1), analytical_area)
+
+    def test_intersection_area_zero(self):
+        # Verifies that the intersection area of two circles is calculated correctly
+        circle1 = Circle(center=(0, 0), radius=5)
+        circle2 = Circle(center=(0, 50), radius=5)
+        circle3 = Circle(center=(0, -10), radius=5)
+
+        self.assertEqual(circle1.intersection_area(circle2), 0)
+        self.assertEqual(circle2.intersection_area(circle1), 0)
+
+        self.assertEqual(circle1.intersection_area(circle3), 0)
+        self.assertEqual(circle3.intersection_area(circle1), 0)
+
+    def test_intersection_area_contained(self):
+        # Verifies that the intersection area of two circles is calculated correctly
+        circle1 = Circle(center=(0.5, 6.7), radius=50)
+        circle2 = Circle(center=(5, 6.7), radius=5)
+
+        self.assertEqual(circle1.intersection_area(circle2), circle2.area)
+        self.assertEqual(circle2.intersection_area(circle1), circle2.area)
+
+    def test_intersection_area_invalid_units(self):
+        # Verifies that an exception is thrown if attempting to find the area of
+        # intersection of two circles with different units
+        circle1 = Circle(center=(0, 0), radius=5, units='mm')
+        circle2 = Circle(center=(0, 50), radius=5)
+
+        with self.assertRaises(ValueError):
+            circle1.intersection_area(circle2)
+
+    def test_intersection_area_invalid_shape(self):
+        # Verifies that an exception is thrown if attempting to find the area of
+        # intersection of a circle and a shape that isn't a circle
+        circle1 = Circle(center=(0, 0), radius=5, units='mm')
+        shape2 = CartesianPoint2D(0, 0)
+
+        with self.assertRaises(TypeError):
+            circle1.intersection_area(shape2)
 
     def test_is_inside(self):
         # Verifies that points can be correctly identified as inside or

--- a/tests/shapes/geometry/test_circle.py
+++ b/tests/shapes/geometry/test_circle.py
@@ -225,6 +225,22 @@ class Test_Circle(unittest.TestCase):
                 for i in range(num_coordinates):
                     self.assertTrue(np.allclose(points[i], expected_points[i]))
 
+    def test_reflect(self):
+        # Verifies that a circle can be reflected about an arbitrary line
+        pntA = CartesianPoint2D(6, 0)
+        pntB = CartesianPoint2D(6, 3)
+
+        self.circle.reflect(pntA=pntA, pntB=pntB)
+
+        with self.subTest(quantity='position'):
+            self.assertLessEqual(
+                self.circle.center.distance_to(CartesianPoint2D(10.8, 3.5)),
+                TEST_FLOAT_TOLERANCE,
+            )
+
+        with self.subTest(quantity='radius'):
+            self.assertEqual(self.circle.radius, self.circle_radius)
+
     def test_rotate(self):
         # Verifies that circle can be rotated about a point
         with self.subTest(center=(0, 0)):

--- a/tests/shapes/geometry/test_circle.py
+++ b/tests/shapes/geometry/test_circle.py
@@ -65,6 +65,10 @@ class Test_Circle(unittest.TestCase):
             "<class 'mahautils.shapes.geometry.circle.Circle'> center=(1.2, 3.5), radius=5.0"
         )
 
+    def test_area(self):
+        # Verifies that the circle area is calculated correctly
+        self.assertAlmostEqual(self.circle.area, 78.53981633974483)
+
     def test_set_center(self):
         # Verifies that circle center point can be set correctly
         with self.subTest(method='constructor'):

--- a/tests/shapes/geometry/test_point.py
+++ b/tests/shapes/geometry/test_point.py
@@ -285,6 +285,78 @@ class Test_CartesianPoint2D_Distance(Test_CartesianPoint2D):
 
 
 class Test_CartesianPoint2D_Transform(Test_CartesianPoint2D):
+    def test_reflect(self):
+        # Verifies that a point can be reflected about an arbitrary line
+        with self.subTest(line='horizontal'):
+            pntA = CartesianPoint2D(-1, 4)
+            pntB = CartesianPoint2D(5, 4)
+
+            point = CartesianPoint2D(2, -21)
+            point.reflect(pntA=pntA, pntB=pntB)
+
+            self.assertEqual(point, CartesianPoint2D(2, 29))
+
+        with self.subTest(line='vertical'):
+            pntA = CartesianPoint2D(-1, 4)
+            pntB = CartesianPoint2D(-1, 9)
+
+            point = CartesianPoint2D(2, -21)
+            point.reflect(pntA=pntA, pntB=pntB)
+
+            self.assertEqual(point, CartesianPoint2D(-4, -21))
+
+        with self.subTest(line='angled'):
+            pntA = CartesianPoint2D(0, 0)
+            pntB = CartesianPoint2D(4, 3)
+
+            point = CartesianPoint2D(1, 7)
+            point.reflect(pntA=pntA, pntB=pntB)
+
+            self.assertEqual(point, CartesianPoint2D(7, -1))
+
+        with self.subTest(line='on_line'):
+            pntA = CartesianPoint2D(-1, 4)
+            pntB = CartesianPoint2D(5, 4)
+
+            point = CartesianPoint2D(2, 4)
+            point.reflect(pntA=pntA, pntB=pntB)
+
+            self.assertEqual(point, CartesianPoint2D(2, 4))
+
+        with self.subTest(line='tuple'):
+            pntA = (-1, 4)
+            pntB = (5, 4)
+
+            point = CartesianPoint2D(2, -21)
+            point.reflect(pntA=pntA, pntB=pntB)
+
+            self.assertEqual(point, CartesianPoint2D(2, 29))
+
+    def test_reflect_x(self):
+        # Verifies that a point can be reflected about the x-axis
+        point = CartesianPoint2D(2, -21)
+        point.reflect_x()
+
+        self.assertEqual(point, CartesianPoint2D(2, 21))
+
+    def test_reflect_y(self):
+        # Verifies that a point can be reflected about the y-axis
+        point = CartesianPoint2D(2, -21)
+        point.reflect_y()
+
+        self.assertEqual(point, CartesianPoint2D(-2, -21))
+
+    def test_reflect_invalid(self):
+        # Verifies that an exception is thrown if attempting to specify a
+        # line with one point
+        pntA = CartesianPoint2D(-1, 4)
+        pntB = CartesianPoint2D(-1, 4)
+
+        point = CartesianPoint2D(2, -21)
+
+        with self.assertRaises(ValueError):
+            point.reflect(pntA=pntA, pntB=pntB)
+
     def test_rotate(self):
         # Verifies that a point can be rotated about another point
         with self.subTest(center=(0, 0)):

--- a/tests/shapes/geometry/test_polygon.py
+++ b/tests/shapes/geometry/test_polygon.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from mahautils.shapes import Polygon
+from mahautils.shapes import CartesianPoint2D, Polygon
 from tests import max_array_diff, TEST_FLOAT_TOLERANCE
 
 
@@ -135,6 +135,30 @@ class Test_Polygon(unittest.TestCase):
                 polygon.points(repeat_end=True),
                 np.array([[9, 0.5], [9, 2.5], [7.5, 2.5], [7, 0], [8, -1.5], [9, 0.5]])
             ))
+
+    def test_reflect(self):
+        # Verifies that a polygon can be reflected about an arbitrary line
+        test_cases = {
+            'counterclockwise': self.polygon_ccw,
+            'clockwise': self.polygon_cw,
+        }
+
+        pntA = CartesianPoint2D(33, -3.075)
+        pntB = CartesianPoint2D(13, 260)
+
+        for direction, polygon in test_cases.items():
+            with self.subTest(direction=direction):
+                original_polygon = copy.deepcopy(polygon)
+                polygon.reflect(pntA=pntA, pntB=pntB)
+
+                for i, vertex in enumerate(polygon.vertices):
+                    original_vertex = CartesianPoint2D(original_polygon.vertices[i])
+                    original_vertex.reflect(pntA=pntA, pntB=pntB)
+
+                    self.assertLessEqual(
+                        CartesianPoint2D(vertex).distance_to(original_vertex),
+                        TEST_FLOAT_TOLERANCE,
+                    )
 
     def test_rotate(self):
         # Verifies that the polygon can be rotated about a point

--- a/tests/shapes/geometry/test_polygon.py
+++ b/tests/shapes/geometry/test_polygon.py
@@ -18,6 +18,16 @@ class Test_Polygon(unittest.TestCase):
         # Polygon with points ordered clockwise
         self.polygon_cw = Polygon(list(reversed(self.vertices)))
 
+    def test_area(self):
+        # Verifies that the polygon area is computed correctly
+        with self.subTest(shape='triangle'):
+            self.assertEqual(Polygon([[0, 0], [3, 0], [0, 2]]).area, 3.0)
+            self.assertEqual(Polygon([[0, 2], [0, 0], [3, 0]]).area, 3.0)
+
+        with self.subTest(shape='pentagon'):
+            self.assertEqual(self.polygon_ccw.area, 5.625)
+            self.assertEqual(self.polygon_cw.area, 5.625)
+
     def test_set_vertices(self):
         # Verifies that polygon vertices are set correctly
         with self.subTest(repeat=False):


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Major Changes and Improvements
- Added `ClosedShape2D.area` property to compute the area of closed, 2D geometry
  - Implemented area calculations for circles ($A=\pi r^2$) and polygons (using the [Shapely](https://shapely.readthedocs.io/en/stable/manual.html) package)
- Added `Shape2D.reflect()`, `Shape2D.reflect_x()`, and `Shape2D.reflect_y()` methods to reflect shapes across lines

## Minor Updates
- Incremented package version to `0.3.0.dev`

## Notes and References
- https://stackoverflow.com/questions/24467972/calculate-area-of-polygon-given-x-y-coordinates
- https://math.stackexchange.com/questions/1013230/how-to-find-coordinates-of-reflected-point
- https://math.stackexchange.com/questions/256100/how-can-i-find-the-points-at-which-two-circles-intersect
- https://math.stackexchange.com/questions/2188507/how-do-you-find-the-point-of-intersection-of-2-vectors