### PR TITLE
Fix failing Read the Docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@
 furo
 matplotlib
 numpy
-Sphinx
+Sphinx >= 7.0.0
 sphinx_design
 sphinx-copybutton
 sphinx-remove-toctrees


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Bug Fixes
- Added Sphinx version requirement so Read the Docs builds succeed

## Notes and References
- https://stackoverflow.com/questions/77022730/building-html-documentation-with-sphinx-furo-autodoc-error-stylesheet