### PR TITLE
Add methods to reflect geometry in a layer or canvas about a line

### DIFF
--- a/mahautils/shapes/canvas.py
+++ b/mahautils/shapes/canvas.py
@@ -128,6 +128,35 @@ class Canvas(pyxx.arrays.TypedListWithID[Layer]):
 
         return None
 
+    def reflect(self, pntA: Union[Array_Float2, 'CartesianPoint2D'],
+                pntB: Union[Array_Float2, 'CartesianPoint2D']) -> None:
+        """Reflects all shapes in all layers of the canvas about a line
+        specified by two points
+
+        Parameters
+        ----------
+        pntA : list or tuple or CartesianPoint2D
+            One point on the line across which the shape is to be reflected
+        pntB : list or tuple or CartesianPoint2D
+            Another point on the line across which the shape is to be reflected
+        """
+        for layer in self:
+            layer.reflect(pntA=pntA, pntB=pntB)
+
+    def reflect_x(self) -> None:
+        """Reflects all shapes in all layers of the canvas about
+        the :math:`x`-axis
+        """
+        for layer in self:
+            layer.reflect_x()
+
+    def reflect_y(self) -> None:
+        """Reflects all shapes in all layers of the canvas about
+        the :math:`y`-axis
+        """
+        for layer in self:
+            layer.reflect_y()
+
     def rotate(self, center: Union[Array_Float2, CartesianPoint2D],
                angle: float, angle_units: str = 'rad') -> None:
         """Rotates all shapes in all layers of the canvas a given angle in

--- a/mahautils/shapes/layer.py
+++ b/mahautils/shapes/layer.py
@@ -181,6 +181,32 @@ class Layer(pyxx.arrays.TypedListWithID[Shape2D]):
 
         return None
 
+    def reflect(self, pntA: Union[Array_Float2, 'CartesianPoint2D'],
+                pntB: Union[Array_Float2, 'CartesianPoint2D']) -> None:
+        """Reflects all shapes in the layer about a line specified by two points
+
+        Parameters
+        ----------
+        pntA : list or tuple or CartesianPoint2D
+            One point on the line across which the shape is to be reflected
+        pntB : list or tuple or CartesianPoint2D
+            Another point on the line across which the shape is to be reflected
+        """
+        for shape in self:
+            shape.reflect(pntA=pntA, pntB=pntB)
+
+    def reflect_x(self) -> None:
+        """Reflects all shapes in the layer about the :math:`x`-axis
+        """
+        for shape in self:
+            shape.reflect_x()
+
+    def reflect_y(self) -> None:
+        """Reflects all shapes in the layer about the :math:`y`-axis
+        """
+        for shape in self:
+            shape.reflect_y()
+
     def rotate(self, center: Union[Array_Float2, CartesianPoint2D],
                angle: float, angle_units: str = 'rad') -> None:
         """Rotates all shapes in the layer a given angle in the :math:`xy`-plane

--- a/tests/shapes/test_canvas.py
+++ b/tests/shapes/test_canvas.py
@@ -186,11 +186,41 @@ class Test_Canvas_Transform(Test_Canvas):
         self.layer2 = Layer()
         self.canvas = Canvas(self.layer1, self.layer2)
 
+        self.layer1.reflect = Mock()
+        self.layer2.reflect = Mock()
+
+        self.layer1.reflect_x = Mock()
+        self.layer2.reflect_x = Mock()
+
+        self.layer1.reflect_y = Mock()
+        self.layer2.reflect_y = Mock()
+
         self.layer1.rotate = Mock()
-        self.layer1.rotate = Mock()
+        self.layer2.rotate = Mock()
 
         self.layer1.translate = Mock()
-        self.layer1.translate = Mock()
+        self.layer2.translate = Mock()
+
+    def test_reflect(self):
+        # Verifies that reflecting a canvas reflects all layers in the canvas
+        self.canvas.reflect(pntA=(1, 2), pntB=(3, 4))
+
+        self.layer1.reflect.assert_called_once_with(pntA=(1, 2), pntB=(3, 4))
+        self.layer2.reflect.assert_called_once_with(pntA=(1, 2), pntB=(3, 4))
+
+    def test_reflect_x(self):
+        # Verifies that reflecting a canvas reflects all layers in the canvas
+        self.canvas.reflect_x()
+
+        self.layer1.reflect_x.assert_called_once()
+        self.layer2.reflect_x.assert_called_once()
+
+    def test_reflect_y(self):
+        # Verifies that reflecting a canvas reflects all layers in the canvas
+        self.canvas.reflect_y()
+
+        self.layer1.reflect_y.assert_called_once()
+        self.layer2.reflect_y.assert_called_once()
 
     def test_rotate(self):
         # Verifies that rotating a canvas rotates all layers in the canvas

--- a/tests/shapes/test_layer.py
+++ b/tests/shapes/test_layer.py
@@ -281,6 +281,18 @@ class Test_Layer_Transform(Test_Layer):
 
         self.layer = Layer(self.circle1, self.circle2, self.closed_shape)
 
+        self.circle1.reflect = Mock()
+        self.circle2.reflect = Mock()
+        self.closed_shape.reflect = Mock()
+
+        self.circle1.reflect_x = Mock()
+        self.circle2.reflect_x = Mock()
+        self.closed_shape.reflect_x = Mock()
+
+        self.circle1.reflect_y = Mock()
+        self.circle2.reflect_y = Mock()
+        self.closed_shape.reflect_y = Mock()
+
         self.circle1.rotate = Mock()
         self.circle2.rotate = Mock()
         self.closed_shape.rotate = Mock()
@@ -288,6 +300,30 @@ class Test_Layer_Transform(Test_Layer):
         self.circle1.translate = Mock()
         self.circle2.translate = Mock()
         self.closed_shape.translate = Mock()
+
+    def test_reflect(self):
+        # Verifies that reflecting a layer reflects all shapes in the layer
+        self.layer.reflect(pntA=(1, 2), pntB=(3, 4))
+
+        self.circle1.reflect.assert_called_once_with(pntA=(1, 2), pntB=(3, 4))
+        self.circle2.reflect.assert_called_once_with(pntA=(1, 2), pntB=(3, 4))
+        self.closed_shape.reflect.assert_called_once_with(pntA=(1, 2), pntB=(3, 4))
+
+    def test_reflect_x(self):
+        # Verifies that reflecting a layer reflects all shapes in the layer
+        self.layer.reflect_x()
+
+        self.circle1.reflect_x.assert_called_once()
+        self.circle2.reflect_x.assert_called_once()
+        self.closed_shape.reflect_x.assert_called_once()
+
+    def test_reflect_y(self):
+        # Verifies that reflecting a layer reflects all shapes in the layer
+        self.layer.reflect_y()
+
+        self.circle1.reflect_y.assert_called_once()
+        self.circle2.reflect_y.assert_called_once()
+        self.closed_shape.reflect_y.assert_called_once()
 
     def test_rotate(self):
         # Verifies that rotating a layer rotates all shapes in the layer


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Added methods to reflect all shapes in a `Layer` or `Canvas` about a line