### PR TITLE
Add notification when file is uploaded to SimExporter

### DIFF
--- a/mahautils/multics/sim_results_exporter/app.py
+++ b/mahautils/multics/sim_results_exporter/app.py
@@ -105,6 +105,7 @@ _simresults = SimResults()
     Output('export-config-store', 'data'),
     Output('export-options-section', 'children'),
     Output('custom-export-div', 'hidden'),
+    Output('upload-notification', 'is_open'),
     Input('upload-data', 'contents'),
     Input('select-button', 'n_clicks'),
     Input('deselect-button', 'n_clicks'),
@@ -125,9 +126,11 @@ def export_manager(
         config: Optional[Dict[str, Dict[str, Union[bool, str]]]]):
     """Uploads a simulation results file
     """
+    show_upload_notification = False
+
     # If file has not yet been uploaded, only show upload section
     if contents is None:
-        return True, '', True, None, None, True
+        return True, '', True, None, None, True, show_upload_notification
 
     # If user just uploaded a simulation results file, parse it and initialize
     # store with all simulation results variables
@@ -138,9 +141,11 @@ def export_manager(
             return (
                 False,
                 f'Error: Unable to read simulation results file ({exception})',
-                True, None, None, True)
+                True, None, None, True, show_upload_notification
+            )
 
         config = parse_sim_results_vars(_simresults)
+        show_upload_notification = True
 
     # If select all or deselect all buttons were pressed, update store
     if dash.ctx.triggered_id == 'select-button':
@@ -176,9 +181,10 @@ def export_manager(
 
         return (True, '', False, config,
                 dash.html.P('Export configuration is not available in lite mode'),
-                True)
+                True, show_upload_notification)
 
-    return True, '', False, config, export_config_table(_simresults, config), False
+    return (True, '', False, config, export_config_table(_simresults, config),
+            False, show_upload_notification)
 
 
 @app.callback(

--- a/mahautils/multics/sim_results_exporter/upload.py
+++ b/mahautils/multics/sim_results_exporter/upload.py
@@ -3,7 +3,8 @@
 from typing import Dict, Union
 
 # Mypy type checking disabled for packages that are not PEP 561-compliant
-import dash  # type: ignore
+import dash                              # type: ignore
+import dash_bootstrap_components as dbc  # type: ignore
 
 from mahautils.multics.simresults import SimResults
 from mahautils.multics.exceptions import SimResultsDataNotFoundError
@@ -69,5 +70,19 @@ def upload_section():
             hidden=True,
             id='upload-error',
             style={'marginTop': '10px'},
-        )
+        ),
+        dbc.Toast(
+            'Your data file was successfully uploaded.',
+            header='Success!',
+            id='upload-notification',
+            dismissable=True,
+            duration=5000,
+            icon='success',
+            is_open=False,
+            style={
+                'position': 'fixed',
+                'bottom': 10,
+                'right': 10,
+            },
+        ),
     ])


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Modified SimExporter to display a notification when a new simulation results file is successfully uploaded
  - Previously, particularly if a small file was uploaded, there was no visual feedback to the user that a new file had been uploaded, which could be confusing.  Now, a small pop-up is shown in the bottom-right side of the screen for 5 seconds

**Feature Demonstration**
![image](https://github.com/nathan-hess/maha-research-utils/assets/63890205/d5028e91-42de-4af8-aee3-e96c9660ffc4)
