### PR TITLE
Set SimViewer legend titles to variable name by default

### DIFF
--- a/mahautils/multics/sim_results_viewer/app.py
+++ b/mahautils/multics/sim_results_viewer/app.py
@@ -549,8 +549,14 @@ def update_plot_config(
                     if trace_variable in ('', None):
                         trace_units = None
                     else:
+                        # When new data series variable is selected, update units
+                        # to match those in the simulation results file and set
+                        # legend title (if it's blank) to variable name
                         trace_units = (_sim_results_files[trace_file]
                                        .get_units(trace_variable))
+
+                        if trace['name'] in ('', None):
+                            trace_name = trace_variable
 
                 trace['name'] = trace_name
                 trace['file'] = trace_file


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Minor Updates
- Updated SimViewer GUI such that if a new data series variable is selected and no legend title has been assigned, the legend will default to displaying the variable name.  This makes it easier to distinguish lines in the plot without needing to explicitly set a legend title