### PR TITLE
Add SimViewer configuration option to use log scale for y-axis

### DIFF
--- a/mahautils/multics/sim_results_viewer/app.py
+++ b/mahautils/multics/sim_results_viewer/app.py
@@ -307,6 +307,7 @@ def validate_upload_file_name(name: Optional[str]):
     Input({'component': 'plot-config', 'tab': 'y', 'field': 'ymin'}, 'value'),
     Input({'component': 'plot-config', 'tab': 'y', 'field': 'ymax'}, 'value'),
     Input({'component': 'plot-config', 'tab': 'y', 'field': 'tick_spacing'}, 'value'),    # noqa: E501  # pylint: disable=C0301
+    Input({'component': 'plot-config', 'tab': 'y', 'field': 'scale'}, 'value'),           # noqa: E501  # pylint: disable=C0301
     Input({'component': 'plot-config', 'tab': 'y', 'field': 'legend-title'}, 'value'),    # noqa: E501  # pylint: disable=C0301
     Input({'component': 'plot-config', 'tab': 'y', 'field': 'trace-file'}, 'value'),      # noqa: E501  # pylint: disable=C0301
     Input({'component': 'plot-config', 'tab': 'y', 'field': 'trace-variable'}, 'value'),  # noqa: E501  # pylint: disable=C0301
@@ -355,6 +356,7 @@ def update_plot_config(
     y_min,
     y_max,
     y_tick_spacing,
+    y_scaling: str,
     trace_name: Optional[str],
     trace_file: Optional[str],
     trace_variable: Optional[str],
@@ -541,6 +543,7 @@ def update_plot_config(
             y_axis['ymax'] = None if y_max in (None, '') else float(y_max)
             y_axis['tick_spacing'] = None if y_tick_spacing in (None, '') \
                                           else float(y_tick_spacing)  # noqa: E127
+            y_axis['axis_scaling'] = y_scaling
 
             if len(config_y['axes'][y_axis_idx]['traces']) > 0:
                 trace = config_y['axes'][y_axis_idx]['traces'][trace_idx]

--- a/mahautils/multics/sim_results_viewer/load_files.py
+++ b/mahautils/multics/sim_results_viewer/load_files.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 
 from mahautils.multics.simresults import SimResults
 from .constants import GUI_SHORT_NAME, PROJECT_NAME, VERSION
+from .store import default_y_axis_settings
 
 
 def decode_base64(base64_str: str) -> str:
@@ -61,6 +62,13 @@ def load_plot_config(dash_base64_contents: str) -> Tuple[dict, dict, dict]:
         config_general = combined_data['general']
         config_x = combined_data['x']
         config_y = combined_data['y']
+
+        # Add defaults for missing settings for compatibility with older
+        # SimViewer versions
+        for axis in config_y['axes']:  # added in v1.2.0
+            if 'axis_scaling' not in axis:
+                axis['axis_scaling'] = default_y_axis_settings['axis_scaling']
+
     except KeyError as exception:
         exception.args = (
             'Invalid plot configuration JSON file. The file does not contain '

--- a/mahautils/multics/sim_results_viewer/panel/settings_y.py
+++ b/mahautils/multics/sim_results_viewer/panel/settings_y.py
@@ -117,6 +117,17 @@ def render_y_settings(config_y: dict, sim_results_files: SIM_RESULTS_DICT_T,
                 tick_spacing_val=axis['tick_spacing'],
             ),
             dash.html.Br(),
+            dash.html.H5('Axis Scaling'),
+            dbc.RadioItems(
+                options=[
+                    {'label': ' Linear     ',           'value': 'linear'},
+                    {'label': ' Logarithmic (base 10)', 'value': 'log'},
+                ],
+                id={'component': 'plot-config', 'tab': 'y', 'field': 'scale'},
+                value=axis['axis_scaling'],
+                inline=True,
+            ),
+            dash.html.Br(),
             dash.html.Br(),
 
             # Axis data/traces selection

--- a/mahautils/multics/sim_results_viewer/plotting.py
+++ b/mahautils/multics/sim_results_viewer/plotting.py
@@ -167,7 +167,9 @@ def update_graph(config_general: dict, config_x: dict, config_y: dict,
 
                 figure.add_trace(go.Scatter(**plot_data))
 
-            tick_options = {}
+            tick_options: Dict[str, Any] = {
+                'tickformat': '~g',
+            }
 
             if y_axis_data['tick_spacing'] not in (None, ''):
                 tick_options['dtick'] = y_axis_data['tick_spacing']

--- a/mahautils/multics/sim_results_viewer/plotting.py
+++ b/mahautils/multics/sim_results_viewer/plotting.py
@@ -5,6 +5,7 @@ the data graph.
 import itertools
 import math
 import random
+import sys
 from typing import Any, Dict, List
 
 # Mypy type checking disabled for packages that are not PEP 561-compliant
@@ -172,6 +173,12 @@ def update_graph(config_general: dict, config_x: dict, config_y: dict,
                 tick_options['dtick'] = y_axis_data['tick_spacing']
 
             if set_ymin or set_ymax:
+                if y_axis_data['axis_scaling'] == 'log':
+                    # If using log scale for the axis, the "range" parameter
+                    # must specify the exponent of 10 for the axis limits
+                    ymin = math.log10(max(ymin, sys.float_info.min))
+                    ymax = math.log10(max(ymax, sys.float_info.min))
+
                 tick_options['range'] = [ymin, ymax]
 
             if i == 0:
@@ -179,6 +186,7 @@ def update_graph(config_general: dict, config_x: dict, config_y: dict,
                     yaxis={
                         'title': str(y_axis_data['axis_title']),
                         'color': str(y_axis_data.get('color', 'black')),
+                        'type': y_axis_data['axis_scaling'],
                         **tick_options,
                     },
                 )
@@ -191,6 +199,7 @@ def update_graph(config_general: dict, config_x: dict, config_y: dict,
                         'side': 'left',
                         'position': (width_per_axis * (num_active_axes - i - 1)),
                         'color': str(y_axis_data.get('color', 'black')),
+                        'type': y_axis_data['axis_scaling'],
                         **tick_options,
                     }
                 })

--- a/mahautils/multics/sim_results_viewer/store.py
+++ b/mahautils/multics/sim_results_viewer/store.py
@@ -65,6 +65,7 @@ default_y_axis_settings: Dict[str, Any] = {
     'ymin': None,
     'ymax': None,
     'tick_spacing': None,
+    'axis_scaling': 'linear',
     'traces': [],
 }
 


### PR DESCRIPTION
<!--
Document all changes and rationale for changes being submitted in the pull
request in a concise but thorough manner.

Follow the section format defined in this template; if any headings are not
applicable, please remove them.
-->

## Major Changes and Improvements
- Adds new option to SimViewer GUI to plot simulation results with a logarithmic scale on the y-axes
- Tick numbering on the y-axes of SimViewer plots now uses floating-point numbers or scientific notation, avoiding displaying numbers as $2\mu$ (to represent $2*10^{-6}$) as this can be confusing

## Notes and References
- https://d3js.org/d3-format